### PR TITLE
Set volumes when loading settings

### DIFF
--- a/source/g_game.c
+++ b/source/g_game.c
@@ -1086,6 +1086,9 @@ void G_LoadSettings()
 
         V_SetPalLump(_g->gamma);
         V_SetPalette(0);
+
+        S_SetSfxVolume(_g->snd_SfxVolume);
+        S_SetMusicVolume(_g->snd_MusicVolume);
     }
 }
 


### PR DESCRIPTION
The SRAM addition works great, except that volume (particularly music volume) doesn't actually change in the menu screen until you adjust the slider a bit in the options. This fixes that issue and the sounds are the correct volume on game start.