### PR TITLE
Add a save type string

### DIFF
--- a/source/info.c
+++ b/source/info.c
@@ -52,6 +52,13 @@
 
 
 // ********************************************************************
+// GBA save type
+// ********************************************************************
+// This is needed for emulators to know which save type the ROM is using.
+
+static volatile const char save_type[10] = "SRAM_V110";
+
+// ********************************************************************
 // Sprite names
 // ********************************************************************
 // This is the list of sprite 4-character prefixes.  They are searched


### PR DESCRIPTION
This is needed for some emulators to know which save type the GBA cartridge is using.

Fixes #44