### PR TITLE
Added SRAM_Vnnn string for save type detection (fixes #17, #44)

### DIFF
--- a/source/d_main.c
+++ b/source/d_main.c
@@ -100,7 +100,7 @@ static const char* timedemo = NULL;//"demo1";
  *
  * Called by I/O functions when an event is received.
  * Try event handlers for each code area in turn.
- * cph - in the true spirit of the Boom source, let the 
+ * cph - in the true spirit of the Boom source, let the
  *  short ciruit operator madness begin!
  */
 
@@ -658,6 +658,9 @@ static void D_DoomMainSetup(void)
             doomverstr = "Public DOOM";
             break;
     }
+
+    /* Magic string for save type detection for GBA */
+    lprintf(LO_INFO, "SRAM_Vnnn");
 
     /* cphipps - the main display. This shows the build date, copyright, and game type */
 


### PR DESCRIPTION
I'm not familiar about GBA rom structure, but I found that adding `SRAM_Vnnn` string in somewhere of the ROM was enough.
This PR adds magic string into source code so It can be read by Emulators. 

Tested on:
* VisualBoyAdvance-M
* Analogue Pocket - Spiritualized.GBA Core(Since there's no way to force save type on this)
* GBATA - Save type shown as SRAM_Vnnn (256Kbit)